### PR TITLE
[fix] (benchmark) Correct file creation error in text_dataset_dump for paths without a directory

### DIFF
--- a/benchmarks/cpp/utils/utils.py
+++ b/benchmarks/cpp/utils/utils.py
@@ -50,7 +50,9 @@ def text_dataset_dump(input_lens, input_ids, output_lens, task_ids, metadata,
                        output_len=output_lens[i],
                        task_id=task_ids[i]))
     workload = Workload(metadata=metadata, samples=samples)
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    output_dir = os.path.dirname(output_file)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     with open(output_file, 'w') as f:
         json.dump(workload.model_dump(), f)
 


### PR DESCRIPTION
# PR title

[fix] (benchmark) Correct file creation error in text_dataset_dump for paths without a directory

## Description
Currently, the `text_dataset_dump` function in `benchmarks/cpp/utils/utils.py` fails when handling an output filename that does not include a directory path (e.g., `--output "my_dataset.json"`).

This occurs because `os.path.dirname()` returns an empty string `''` for such an input. The subsequent call to `os.makedirs('', exist_ok=True)` is an invalid operation, which results in a `FileNotFoundError: [Errno 2] No such file or directory: ''`.

**Steps to Reproduce:**
This error can be triggered by running the `prepare_dataset.py` script from the `TensorRT-LLM` root directory and providing a filename without a path for the output.

```bash
python3 benchmarks/cpp/prepare_dataset.py --tokenizer . --output my_data.json token-norm-dist ...
```

#### Solution

This change resolves the issue by adding a check before calling `os.makedirs`.

The result of `os.path.dirname(output_file)` is first stored in a variable `output_dir`. The call to `os.makedirs` is then only executed if `output_dir` is not empty (i.e., if the `output_file` argument included a directory path). If `output_dir` is empty, the directory creation step is skipped, and the subsequent `with open(...)` correctly creates the file in the current working directory.

**Code Change Comparison:**

  * **Before:**

    ```python os.makedirs(os.path.dirname(output_file), exist_ok=True) with open(output_file, 'w') as f: json.dump(workload.model_dump(), f) ```

  * **After:**

    ```python output_dir = os.path.dirname(output_file) if output_dir: os.makedirs(output_dir, exist_ok=True) with open(output_file, 'w') as f: json.dump(workload.model_dump(), f) ```

#### Testing and Verification

This fix has been verified as follows:

  * When a path including a directory is used (e.g., `--output build/my_data.json`), the `build` directory is successfully created, and the file is written correctly.
  * When a path without a directory is used (e.g., `--output my_data.json`), the program no longer raises an error, and the file is successfully created in the current working directory.

This modification improves the robustness and user experience of the `prepare_dataset.py` script.

